### PR TITLE
fix typos in account model fields

### DIFF
--- a/account/migrations/0001_initial.py
+++ b/account/migrations/0001_initial.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('update_at', models.DateTimeField(auto_now=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='accounts', to=settings.AUTH_USER_MODEL)),
             ],
         ),
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('update_at', models.DateTimeField(auto_now=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
                 ('follow', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='following', to='account.Account')),
                 ('owner', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='followers', to='account.Account')),
             ],

--- a/account/models.py
+++ b/account/models.py
@@ -4,7 +4,7 @@ from django.db import models
 class Account(models.Model):
     user = models.ForeignKey(to='auth.User', related_name='accounts')
     created_at = models.DateTimeField(auto_now_add=True)
-    update_at = models.DateTimeField(auto_now=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def is_following(self, follow):
         return self.following.filter(follow=follow).exists()
@@ -26,7 +26,7 @@ class Relationship(models.Model):
     owner = models.ForeignKey(to='account.Account', related_name='following')
     follow = models.ForeignKey(to='account.Account', related_name='followers')
     created_at = models.DateTimeField(auto_now_add=True)
-    update_at = models.DateTimeField(auto_now=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         unique_together = ('owner', 'follow',)


### PR DESCRIPTION
To test it: 
 - Remove local database and run migrate command ```$ python manage.py migrate```.